### PR TITLE
Remove hyphens from beginning of place names

### DIFF
--- a/book_extractors/common/extraction_keys.py
+++ b/book_extractors/common/extraction_keys.py
@@ -36,6 +36,7 @@ KEYS = {
     "birthLocation": "birthLocation",
 
     "locationName": "locationName",
+    "stemmedName": "stemmedName",
     "personMetadata": "personMetadata",
 
     "address": "address",

--- a/book_extractors/common/postprocessors/place_name_cleaner.py
+++ b/book_extractors/common/postprocessors/place_name_cleaner.py
@@ -110,3 +110,18 @@ def normalize_place_name_with_known_list_of_places(location_entry, metadata_coll
             if metadata_collector is not None:
                 metadata_collector.add_error_record('locationNameNotFoundFromLists', 2)
             return location_entry
+
+
+def clean_place_name(location_entry):
+    """
+    Utility function to clean up the locationName and stemmedName if one is available from useless
+    characters.
+    :param location_entry: 
+    :return: 
+    """
+    location_entry[KEYS['locationName']] = location_entry[KEYS['locationName']].strip('-')
+
+    if KEYS['stemmedName'] in location_entry:
+        location_entry[KEYS['stemmedName']] = location_entry[KEYS['stemmedName']].strip('-')
+
+    return location_entry

--- a/book_extractors/karelians/extraction/extractors/child_extractor.py
+++ b/book_extractors/karelians/extraction/extractors/child_extractor.py
@@ -127,6 +127,7 @@ class ChildExtractor(BaseExtractor):
                 KEYS['region']: None,
             }
 
+            location_entry = place_name_cleaner.clean_place_name(location_entry)
             child[KEYS["childLocationName"]] = place_name_cleaner.try_to_normalize_place_name(location_entry, self.metadata_collector)
 
             coordinates = self._find_birth_coord(child[KEYS["childLocationName"]][KEYS['locationName']])

--- a/book_extractors/karelians/extraction/extractors/location_extractor.py
+++ b/book_extractors/karelians/extraction/extractors/location_extractor.py
@@ -65,6 +65,7 @@ class BirthdayLocationExtractor(BaseExtractor):
             KEYS['region']: None,
         }
 
+        location_entry = place_name_cleaner.clean_place_name(location_entry)
         return place_name_cleaner.try_to_normalize_place_name(location_entry, self.metadata_collector)
 
     def _prepare_text_for_extraction(self, text, start_position):

--- a/book_extractors/karelians/extraction/extractors/migration_route_extractors.py
+++ b/book_extractors/karelians/extraction/extractors/migration_route_extractors.py
@@ -1,5 +1,5 @@
 import re
-
+from book_extractors.common.postprocessors import place_name_cleaner
 from book_extractors.common.extraction_keys import KEYS
 from book_extractors.common.extractors.base_extractor import BaseExtractor
 from book_extractors.karelians.extraction.extractors.bnf_parsers import migration_parser
@@ -137,9 +137,17 @@ class FinnishLocationsExtractor(BaseExtractor):
                     else:
                         moved_out = None
 
-                    location_records.append(get_location_entry())
+                    location_records.append(
+                        place_name_cleaner.clean_place_name(
+                            get_location_entry()
+                        )
+                    )
             else:
-                location_records.append(get_location_entry())
+                location_records.append(
+                    place_name_cleaner.clean_place_name(
+                        get_location_entry()
+                    )
+                )
 
             return location_records
 
@@ -147,7 +155,7 @@ class FinnishLocationsExtractor(BaseExtractor):
             found_locations = regexUtils.safe_search(self.LOCATION_PATTERN, text, self.LOCATION_OPTIONS)
             cursor_location = found_locations.end()
             locations = found_locations.group("asuinpaikat")
-            locations = self._clean_locations(locations)
+            locations = self._clean_locations_string(locations)
 
             # Parse location string with BNF parser
             parsed_locations = migration_parser.parse_locations(locations)
@@ -163,7 +171,7 @@ class FinnishLocationsExtractor(BaseExtractor):
         return location_entries, cursor_location
 
     @staticmethod
-    def _clean_locations(locations):
+    def _clean_locations_string(locations):
         locations = locations.strip(",")
         locations = locations.strip(".")
         locations = locations.strip()
@@ -272,9 +280,17 @@ class KarelianLocationsExtractor(BaseExtractor):
                     except TypeError:
                         pass
 
-                    location_records.append(get_location_entry())
+                    location_records.append(
+                        place_name_cleaner.clean_place_name(
+                            get_location_entry()
+                        )
+                    )
             else:
-                location_records.append(get_location_entry())
+                location_records.append(
+                    place_name_cleaner.clean_place_name(
+                        get_location_entry()
+                    )
+                )
 
             return location_records
 

--- a/book_extractors/karelians/tests/extraction/locations/mock_person_data.py
+++ b/book_extractors/karelians/tests/extraction/locations/mock_person_data.py
@@ -41,6 +41,13 @@ LOCATION_HEURISTICS = {
                     "miellyttävät häntä. Hän on ollut asevarikkotehtävissä v.30—68.",
     },
 
+    'name_with_extra_hyphens': {
+            'text': "Asuinp. Karjalassa; -Viipuri 23—39. Muut asuinp.: Kankaanpää 39— 40, "
+                    "Hirvensalo -40, Perniö -40, -Ähtäri, Hankavesi 41—44, Kristiinankaupungin mlk 45-. Aholat asuvat itse rakentamassaan omakotitalossa. "
+                    "Herra Ahola on sotamies. Hän on saanut kunniamerkit Ts mm, Js mm, SVR m 1 ja SVR m 2. Kalastus ja puutarhanhoito "
+                    "miellyttävät häntä. Hän on ollut asevarikkotehtävissä v.30—68.",
+    },
+
 
     'short_place_name': {
         'text': "Asuinp. Karjalassa; Viipuri 23—39, ktr. Muut asuinp.: Kankaanpää, ja 39— 40, "

--- a/book_extractors/karelians/tests/extraction/locations/test_location_extraction.py
+++ b/book_extractors/karelians/tests/extraction/locations/test_location_extraction.py
@@ -120,6 +120,12 @@ class TestFinnishLocationExtraction:
         assert len(results) == 5
         assert results[4]['locationName'] == 'Kristiinankaupungin mlk'
 
+    def should_remove_hyphens_from_beginning_of_the_place_name(self, finnish_extractor):
+        results = finnish_extractor.extract({'text': LOCATION_HEURISTICS['name_with_extra_hyphens']['text']}, {})['finnishLocations']['results']
+
+        assert len(results) == 5
+        assert results[3]['locationName'] == 'Ähtäri'   # Hyphen from beginning removed
+
 
 class TestKarelianLocationExtraction:
 
@@ -216,6 +222,12 @@ class TestKarelianLocationExtraction:
 
         assert len(results) == 1
         assert results[0]['locationName'] == 'Kristiinankaupungin mlk'
+
+    def should_remove_hyphens_from_beginning_of_the_place_name(self, karelian_extractor):
+        results = karelian_extractor.extract({'text': LOCATION_HEURISTICS['name_with_extra_hyphens']['text']}, {})['karelianLocations']['results']['karelianLocations']
+
+        assert len(results) == 1
+        assert results[0]['locationName'] == 'Viipuri'   # Hyphen from beginning removed
 
 
 class TestMigrationRouteExtractor:


### PR DESCRIPTION
There were quite a few extra locations in the database which had names like
"-Helsinki". Remove hyphens if they are first in the name so that place names can 
then be grouped correctly together in the db.