### PR TITLE
Fix migration history place names with manually fixed list

### DIFF
--- a/book_extractors/common/postprocessors/place_name_cleaner.py
+++ b/book_extractors/common/postprocessors/place_name_cleaner.py
@@ -50,7 +50,9 @@ def try_to_normalize_place_name(location_entry, metadata_collector=None):
         search_key = stemmer.stem(location_entry[KEYS['locationName']])
         if search_key in manual_place_name_index:
             location_entry[KEYS['locationName']] = manual_place_name_index[search_key]['fixed_name']
-            location_entry[KEYS['region']] = manual_place_name_index[search_key]['region']
+
+            if manual_place_name_index[search_key]['region'] is not None:
+                location_entry[KEYS['region']] = manual_place_name_index[search_key]['region']
         else:
             location_entry = normalize_place_name_with_known_list_of_places(location_entry, metadata_collector)
 

--- a/book_extractors/karelians/extraction/extractors/migration_route_extractors.py
+++ b/book_extractors/karelians/extraction/extractors/migration_route_extractors.py
@@ -67,7 +67,18 @@ class FinnishLocationsExtractor(BaseExtractor):
 
     def _extract(self, entry, extraction_results):
         location_listing_results = self._find_locations(entry['text'])
-        return self._add_to_extraction_results(location_listing_results[0], extraction_results, location_listing_results[1])
+
+        return self._add_to_extraction_results({
+            KEYS["otherlocations"]: location_listing_results[0]},
+            extraction_results, location_listing_results[1])
+
+    def _postprocess(self, entry, extraction_results):
+        places = extraction_results[self.extraction_key]['results'][KEYS["otherlocations"]]
+
+        for i in range(0, len(places)):
+            places[i] = place_name_cleaner.try_to_normalize_place_name(places[i])
+
+        return extraction_results
 
     def _find_locations(self, text):
         # Replace all weird invisible white space characters with regular space
@@ -205,6 +216,14 @@ class KarelianLocationsExtractor(BaseExtractor):
             KEYS["karelianlocations"]: location_listing_results[0],
         }, extraction_results, location_listing_results[1])
 
+    def _postprocess(self, entry, extraction_results):
+        places = extraction_results[self.extraction_key]['results'][KEYS["karelianlocations"]]
+
+        for i in range(0, len(places)):
+            places[i] = place_name_cleaner.try_to_normalize_place_name(places[i])
+
+        return extraction_results
+
     def _find_locations(self, text):
         # Replace all weird invisible white space characters with regular space
         text = re.sub(r"\s", r" ", text)
@@ -336,7 +355,7 @@ class MigrationRouteExtractor(BaseExtractor):
         results = self._sub_extraction_pipeline.process(entry)
 
         return self._add_to_extraction_results({
-            KEYS["locations"]: results['karelianLocations']['results'][KEYS['karelianlocations']] + results['finnishLocations']['results']
+            KEYS["locations"]: results['karelianLocations']['results'][KEYS['karelianlocations']] + results['finnishLocations']['results'][KEYS['otherlocations']]
         }, extraction_results, results['finnishLocations']['metadata']['cursorLocation'])
 
     def _postprocess(self, entry, extraction_results):

--- a/book_extractors/karelians/tests/extraction/locations/mock_person_data.py
+++ b/book_extractors/karelians/tests/extraction/locations/mock_person_data.py
@@ -20,6 +20,49 @@ LOCATION_TEXTS = [
     "autonkuljettaja, synt. 1. 12. -33 Valkjärvellä. Puol. Testi Testinen o.s. Testaaja, rouva, synt. 24. 6. -32 Kempeleellä. Lapset: Lapsi -54 Längelmäki, Lapsekas -57 Längelmäki, Lapsellinen -61 Längelmäki. Asuinp. Karjalassa: Valkjärvi, Marjaniemi -39,42—44. Muut asuinp.. Ypäjä 39—42, Kuhmoinen, Längelmäki, Hiukkaa, Längelmäki. Länkipohja. Aikaisemmin Karjalaisilla oli maatila, mutta vanhaemännän kuoltua se myytiin ja lapset muuttivat muualle. Herra Karjalainen on ollut vuodesta -59 Längelmäen Osuuskaupan palveluksessa. Ensi Karjalaisen isä. Antti, synt. -97 Valkjärvellä, kuoli Kangasalalla v. -66. Äiti. Hilda o.s. Paavilainen, synt. 1900, kuöli -53 Längelmäellä."
 ]
 
+LOCATION_TEXTS_WITH_INCORRECT_REGION = [
+    {'text': "Poika -53 Helsinki. Asuinp. Karjalassa: Uusi kirkko. Lempiälä 12—28, Helsinki 28—. Muut asuinp.: Helsinki mlk. Testiset asuvat",
+     'expected': [
+        {
+            "movedOut": 28,
+            "village": {
+              "locationName": "Lempiälä"
+            },
+            "movedIn": 12,
+            "region": "karelia",
+            "locationName": "Uusikirkko"
+        }, {
+            "movedOut": None,
+            "village": {
+              "locationName": None
+            },
+            "movedIn": 28,
+            "region": "other",
+            "locationName": "Helsinki"
+        }]
+     },
+    {'text': "Poika -53 Helsinki. Asuinp. Karjalassa: Uusi kirkko. Lempiälä 12—28. Muut asuinp.: Kanneljärvi 28—. Testiset asuvat",
+     'expected': [
+        {
+            "movedOut": 28,
+            "village": {
+              "locationName": "Lempiälä"
+            },
+            "movedIn": 12,
+            "region": "karelia",
+            "locationName": "Uusikirkko"
+        }, {
+            "movedOut": None,
+            "village": {
+              "locationName": None
+            },
+            "movedIn": 28,
+            "region": "karelia",
+            "locationName": "Kanneljärvi"
+        }]
+     }
+]
+
 LOCATION_HEURISTICS = {
     'long_name_with_mlk': {
             'text': "Asuinp. Karjalassa; Kristiinankaupungin mlk 23—39. Muut asuinp.: Kankaanpää 39— 40, "

--- a/extract_all.sh
+++ b/extract_all.sh
@@ -1,0 +1,4 @@
+python main.py -i material/siirtokarjalaiset_I.xml -o material/siirtokarjalaiset_I.json
+python main.py -i material/siirtokarjalaiset_II.xml -o material/siirtokarjalaiset_I.json
+python main.py -i material/siirtokarjalaiset_III.xml -o material/siirtokarjalaiset_I.json
+python main.py -i material/siirtokarjalaiset_IV.xml -o material/siirtokarjalaiset_I.json


### PR DESCRIPTION
Previously migration history place names were not ran through the postprocess
which would fix incorrect regions etc. Now do that. Also do not overwrite Kaira
produced region with None from manually fixed list.