### PR TITLE
Generate independent ids for children and spouses

### DIFF
--- a/book_extractors/common/extractors/kaira_id_extractor.py
+++ b/book_extractors/common/extractors/kaira_id_extractor.py
@@ -3,7 +3,9 @@ import book_extractors.extraction_constants as extraction_constants
 
 
 class KairaIdProvider:
-    _id_num = 1
+    _main_id_num = 1
+    _children_id_num = 1
+    _spouse_id_num = 1
 
     _allowed_person_types = {
         'P': 'primary',
@@ -12,14 +14,31 @@ class KairaIdProvider:
     }
 
     def reset(self):
-        KairaIdProvider._id_num = 1
+        KairaIdProvider._main_id_num = 1
+        KairaIdProvider._children_id_num = 1
+        KairaIdProvider._spouse_id_num = 1
 
     def get_new_id(self, person_type='P'):
         if person_type not in KairaIdProvider._allowed_person_types:
             raise Exception('Not a proper person type for kairaId assigned.')
 
-        full_id = '{}_{}_{}{}'.format(extraction_constants.BOOK_SERIES, extraction_constants.BOOK_NUMBER, KairaIdProvider._id_num, person_type)
-        KairaIdProvider._id_num += 1
+        if person_type == 'P':
+            KairaIdProvider._children_id_num = 1
+            KairaIdProvider._spouse_id_num = 1
+
+            full_id = '{}_{}_{}{}'.format(extraction_constants.BOOK_SERIES, extraction_constants.BOOK_NUMBER,
+                                          KairaIdProvider._main_id_num, person_type)
+            KairaIdProvider._main_id_num += 1
+
+        if person_type == 'S':
+            full_id = '{}_{}_{}{}_{}'.format(extraction_constants.BOOK_SERIES, extraction_constants.BOOK_NUMBER,
+                                          KairaIdProvider._main_id_num, person_type, KairaIdProvider._spouse_id_num)
+            KairaIdProvider._spouse_id_num += 1
+
+        if person_type == 'C':
+            full_id = '{}_{}_{}{}_{}'.format(extraction_constants.BOOK_SERIES, extraction_constants.BOOK_NUMBER,
+                                          KairaIdProvider._main_id_num, person_type, KairaIdProvider._children_id_num)
+            KairaIdProvider._children_id_num += 1
 
         return full_id
 

--- a/book_extractors/farmers/tests/extraction/children/mock_person_data.py
+++ b/book_extractors/farmers/tests/extraction/children/mock_person_data.py
@@ -14,18 +14,18 @@ EXPECTED_CHILDREN = [
         "birthYear": 1937,
         "gender": "Female",
         "name": "Maija Sanelma",
-        "kairaId": 'testbook_1_1C'
+        "kairaId": 'testbook_1_1C_1'
     },
     {
         "birthYear": 1939,
         "gender": "Male",
         "name": "Raimo Juhani",
-        "kairaId": 'testbook_1_2C'
+        "kairaId": 'testbook_1_1C_2'
     },
     {
         "birthYear": 1942,
         "gender": "Male",
         "name": "Pentti Kaarlo Kalevi",
-        "kairaId": 'testbook_1_3C'
+        "kairaId": 'testbook_1_1C_3'
     }
 ]

--- a/book_extractors/karelians/tests/extraction/children/mock_person_data.py
+++ b/book_extractors/karelians/tests/extraction/children/mock_person_data.py
@@ -13,7 +13,7 @@ EXPECTED = [
             'region': 'other'
         },
         'name': 'Irja Hellevi',
-        'kairaId': 'testbook_1_1C'
+        'kairaId': 'testbook_1_1C_1'
     },
     {
         'birthYear': 1947,
@@ -23,7 +23,7 @@ EXPECTED = [
             'region': 'other'
         },
         'name': 'Kirsti Anna-Liisa',
-        'kairaId': 'testbook_1_2C'
+        'kairaId': 'testbook_1_1C_2'
     },
     {
         'birthYear': 1953,
@@ -33,6 +33,6 @@ EXPECTED = [
             'region': 'other'
         },
         'name': 'Kalervo Viljam',
-        'kairaId': 'testbook_1_3C'
+        'kairaId': 'testbook_1_1C_3'
     }
 ]

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -5,6 +5,7 @@ import shutil
 import json
 from lxml import etree
 
+
 class TestCommandLineSmoke:
     class TestExtraction:
         @pytest.yield_fixture(autouse=True)
@@ -29,12 +30,12 @@ class TestCommandLineSmoke:
             assert len(result_data) == 3
 
             # Check that each person has unique id
-            assert result_data[0]['primaryPerson']['kairaId'] == 'siirtokarjalaiset_1_3P'
-            assert result_data[0]['spouse']['kairaId'] == 'siirtokarjalaiset_1_1S'
-            assert result_data[1]['primaryPerson']['kairaId'] == 'siirtokarjalaiset_1_5P'
-            assert result_data[1]['spouse']['kairaId'] == 'siirtokarjalaiset_1_4S'
-            assert result_data[2]['primaryPerson']['kairaId'] == 'siirtokarjalaiset_1_10P'
-            assert result_data[2]['spouse']['kairaId'] == 'siirtokarjalaiset_1_6S'
+            assert result_data[0]['primaryPerson']['kairaId'] == 'siirtokarjalaiset_1_1P'
+            assert result_data[0]['spouse']['kairaId'] == 'siirtokarjalaiset_1_1S_1'
+            assert result_data[1]['primaryPerson']['kairaId'] == 'siirtokarjalaiset_1_2P'
+            assert result_data[1]['spouse']['kairaId'] == 'siirtokarjalaiset_1_2S_1'
+            assert result_data[2]['primaryPerson']['kairaId'] == 'siirtokarjalaiset_1_3P'
+            assert result_data[2]['spouse']['kairaId'] == 'siirtokarjalaiset_1_3S_1'
 
         def should_return_correct_birthlocation_without_control_characters(self):
             # FIXME: Move this test to some kind of preprocessor class when relevant implementation code is moved from
@@ -61,9 +62,9 @@ class TestCommandLineSmoke:
             assert len(result_data) == 3
 
             # Check that each entry has unique id
-            assert result_data[0]['kairaId'] == 'pienviljelijat_1_2P'
-            assert result_data[1]['kairaId'] == 'pienviljelijat_1_3P'
-            assert result_data[2]['kairaId'] == 'pienviljelijat_1_9P'
+            assert result_data[0]['kairaId'] == 'pienviljelijat_1_1P'
+            assert result_data[1]['kairaId'] == 'pienviljelijat_1_2P'
+            assert result_data[2]['kairaId'] == 'pienviljelijat_1_3P'
 
         def should_process_great_farmers_xml_and_save_to_json(self):
             file_path = 'temp/json_export_tests/results.json'
@@ -77,12 +78,12 @@ class TestCommandLineSmoke:
             assert len(result_data) == 3
 
             # Check that each person has unique id
-            assert result_data[0]['kairaId'] == 'suuretmaatilat_1_2P'
-            assert result_data[0]['spouse']['kairaId'] == 'suuretmaatilat_1_1S'
-            assert result_data[1]['kairaId'] == 'suuretmaatilat_1_4P'
-            assert result_data[1]['spouse']['kairaId'] == 'suuretmaatilat_1_3S'
-            assert result_data[2]['kairaId'] == 'suuretmaatilat_1_7P'
-            assert result_data[2]['spouse']['kairaId'] == 'suuretmaatilat_1_5S'
+            assert result_data[0]['kairaId'] == 'suuretmaatilat_1_1P'
+            assert result_data[0]['spouse']['kairaId'] == 'suuretmaatilat_1_1S_1'
+            assert result_data[1]['kairaId'] == 'suuretmaatilat_1_2P'
+            assert result_data[1]['spouse']['kairaId'] == 'suuretmaatilat_1_2S_1'
+            assert result_data[2]['kairaId'] == 'suuretmaatilat_1_3P'
+            assert result_data[2]['spouse']['kairaId'] == 'suuretmaatilat_1_3S_1'
 
         def should_error_if_unsupported_xml_is_read(self):
             file_path = 'temp/json_export_tests/results.json'


### PR DESCRIPTION
Problem was that before the id was incremented for every person type. This would
be extremely bad thing if the count of children and spouses would change (and they
will change!). Now main id is based on data entries which should be reasonably stable and children and spouses will get incrementing id which is under the
main id.