### PR TITLE
Add support for ha:na and ha.na patterns in farm area extraction

### DIFF
--- a/book_extractors/karelians/extraction/extractors/farm_area_extractor.py
+++ b/book_extractors/karelians/extraction/extractors/farm_area_extractor.py
@@ -12,11 +12,13 @@ class FarmAreaExtractor(BaseExtractor):
     def __init__(self, key_of_cursor_location_dependent, options):
         super(FarmAreaExtractor, self).__init__(key_of_cursor_location_dependent, options)
         self.OPTIONS = (regex.UNICODE | regex.IGNORECASE)
-        self.PATTERN_MATCH = r'(pinta-ala){s<=1}\son\s(?P<area>\d{1,3}(?:,|\.)\d{1,2}|\d{1,3}(?!\s\d))\s?(?P<unit>ha|m|aar)'
-        self.AREA_REGEX = regex.compile(self.PATTERN_MATCH, self.OPTIONS)
+        self.PATTERN_MATCH_PINTAALA_ON = r'(pinta-ala){s<=1}\son\s(?P<area>\d{1,3}(?:,|\.)\d{1,2}|\d{1,3}(?!\s\d))\s?(?P<unit>ha|m|aar)'
+        self.PATTERN_MATCH_AREA_HA_NA = r'(?P<area>(\d{1,3}(?:,|\.)\d{1,3})|(?<!\d\s)\d{1,3}(?!\s\d))(?=\sha(:n|\.n))'
+        self.REGEX_PINTAALA_ON = regex.compile(self.PATTERN_MATCH_PINTAALA_ON, self.OPTIONS)
+        self.REGEX_HA_NA = regex.compile(self.PATTERN_MATCH_AREA_HA_NA, self.OPTIONS)
 
     def _extract(self, entry, extraction_results, extraction_metadata):
-        matches = self.AREA_REGEX.search(entry['text'])
+        matches = self.REGEX_PINTAALA_ON.search(entry['text'])
         area_in_hectares = None
 
         if matches:
@@ -28,5 +30,10 @@ class FarmAreaExtractor(BaseExtractor):
                     area_in_hectares = number / 100
                 else:
                     area_in_hectares = number
+        else:
+            matches = self.REGEX_HA_NA.search(entry['text'])
+
+            if matches:
+                area_in_hectares = float(matches.group('area').replace(',', '.'))
 
         return self._add_to_extraction_results(area_in_hectares, extraction_results, extraction_metadata)

--- a/book_extractors/karelians/extraction/extractors/tests/test_farm_extraction.py
+++ b/book_extractors/karelians/extraction/extractors/tests/test_farm_extraction.py
@@ -76,32 +76,54 @@ class TestFarmAreaExtraction:
     def farm_area_extractor(self):
         return FarmAreaExtractor(None, None)
 
-    def should_extract_hectares_correctly_as_float(self, farm_area_extractor):
-        results, metadata = farm_area_extractor.extract({'text': 'Anonyymit asuvat maatilallaan, jonka pinta-ala on 35.20 ha ja siitä on viljeltyä 3.37 ha.'}, {}, {})
-        assert results['farmTotalArea'] == 35.2
+    class TestFarmAreaIsPattern:
+        def should_extract_hectares_correctly_as_float(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Anonyymit asuvat maatilallaan, jonka pinta-ala on 35.20 ha ja siitä on viljeltyä 3.37 ha.'}, {}, {})
+            assert results['farmTotalArea'] == 35.2
 
-        results, metadata = farm_area_extractor.extract({'text': 'Nimettömät asuvat tilalla, jonka pinta-ala on 21,61 ha ja viljelyksiä on 7,79 ha.'}, {}, {})
-        assert results['farmTotalArea'] == 21.61
+            results, metadata = farm_area_extractor.extract({'text': 'Nimettömät asuvat tilalla, jonka pinta-ala on 21,61 ha ja viljelyksiä on 7,79 ha.'}, {}, {})
+            assert results['farmTotalArea'] == 21.61
 
-    def should_extract_hectares_correctly_as_float_if_hectare_unit_contains_typo(self, farm_area_extractor):
-        results, metadata = farm_area_extractor.extract({'text': 'Perhe asuu tilalla, jonka pinta-ala on 28,5 haja viljelyksiä on 15 ha Heidän poikansa Taavi hoitaa tilaa.'}, {}, {})
-        assert results['farmTotalArea'] == 28.5
+        def should_extract_hectares_correctly_as_float_if_hectare_unit_contains_typo(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Perhe asuu tilalla, jonka pinta-ala on 28,5 haja viljelyksiä on 15 ha Heidän poikansa Taavi hoitaa tilaa.'}, {}, {})
+            assert results['farmTotalArea'] == 28.5
 
-    def should_extract_hectares_correctly_as_float_if_area_is_in_ares(self, farm_area_extractor):
-        results, metadata = farm_area_extractor.extract({'text': 'Pa-lonkylä 44- Satunnaisella ihmisellä on oma talo. jonka tontin pinta ala on 10 aaria.'}, {}, {})
-        assert results['farmTotalArea'] == 10/100
+        def should_extract_hectares_correctly_as_float_if_area_is_in_ares(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Pa-lonkylä 44- Satunnaisella ihmisellä on oma talo. jonka tontin pinta ala on 10 aaria.'}, {}, {})
+            assert results['farmTotalArea'] == 10/100
 
-    def should_extract_none_if_contains_whitespace_in_number(self, farm_area_extractor):
-        results, metadata = farm_area_extractor.extract({'text': 'Meikäläisillä on asutustila, jonka pinta-ala on 1 9 ha ja siitä on viljeltyä 4 ha.'}, {}, {})
-        assert results['farmTotalArea'] is None
+        def should_extract_none_if_contains_whitespace_in_number(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Meikäläisillä on asutustila, jonka pinta-ala on 1 9 ha ja siitä on viljeltyä 4 ha.'}, {}, {})
+            assert results['farmTotalArea'] is None
 
-    def should_extract_none_if_data_does_not_contain_total_area(self, farm_area_extractor):
-        results, metadata = farm_area_extractor.extract({'text': 'Jonkun perhe asuu maatilallaan. Pinta-alasta on viljeltyä 2,7 ha ja metsää 0,3 ha.'}, {}, {})
-        assert results['farmTotalArea'] is None
+        def should_extract_none_if_data_does_not_contain_total_area(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Jonkun perhe asuu maatilallaan. Pinta-alasta on viljeltyä 2,7 ha ja metsää 0,3 ha.'}, {}, {})
+            assert results['farmTotalArea'] is None
 
-    def should_extract_none_if_area_is_in_square_meters(self, farm_area_extractor):
-        results, metadata = farm_area_extractor.extract({'text': 'Nyymeillä on myös Helsingissä Tikkurilassa kaksikerroksinen asuintalo, jonka pinta-ala on 270 m'}, {}, {})
-        assert results['farmTotalArea'] is None
+        def should_extract_none_if_area_is_in_square_meters(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Nyymeillä on myös Helsingissä Tikkurilassa kaksikerroksinen asuintalo, jonka pinta-ala on 270 m'}, {}, {})
+            assert results['farmTotalArea'] is None
 
-        results, metadata = farm_area_extractor.extract({'text': 'Testiperheellä on kesäasunto Ristiinkäytävän järven rannalla. Tontin pinta-ala on n. 2300 m'}, {}, {})
-        assert results['farmTotalArea'] is None
+            results, metadata = farm_area_extractor.extract({'text': 'Testiperheellä on kesäasunto Ristiinkäytävän järven rannalla. Tontin pinta-ala on n. 2300 m'}, {}, {})
+            assert results['farmTotalArea'] is None
+
+    class TestFarmAreaHaPattern:
+        def should_extract_hectares_correctly_as_float_if_dot_in_unit_of_area(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Satunnaiset asuvat 20 ha.n suuruisella tilallaan, josta on viljeltyä 12.75 ha.'}, {}, {})
+            assert results['farmTotalArea'] == 20
+
+        def should_extract_hectares_correctly_as_float_if_colon_in_unit_of_area(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Jotkut asuvat 133 ha:n suuruisella maatilallaan, jossa on 7 ha viljeltyä.'}, {}, {})
+            assert results['farmTotalArea'] == 133
+
+        def should_extract_hectares_correctly_as_float_if_comma_in_value_of_area(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Anonyymit asuvat 112,23 ha:n suuruisella maatilalla, jossa on 12 ha viljeltyä.'}, {}, {})
+            assert results['farmTotalArea'] == 112.23
+
+        def should_extract_hectares_correctly_as_float_if_dot_in_value_of_area(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Testiset asuvat 7.3 ha.n suuruisella asutustilallaan, jossa on 5 ha viljeltyä.'}, {}, {})
+            assert results['farmTotalArea'] == 7.3
+
+        def should_extract_hectares_correctly_as_none_if_whitespace_in_value_of_area(self, farm_area_extractor):
+            results, metadata = farm_area_extractor.extract({'text': 'Testiset asuvat1 7 ha.n suuruisella asutustilallaan, jossa on 5 ha viljeltyä.'}, {}, {})
+            assert results['farmTotalArea'] is None


### PR DESCRIPTION
The extractor for farmTotalArea now supports the ha:na and ha.na patterns
and the appropriate tests for those patterns have also been implemented.