### PR TITLE
Add an extractor for injured in war flag

### DIFF
--- a/book_extractors/karelians/extraction/extractors/injured_in_war_flag_extractor.py
+++ b/book_extractors/karelians/extraction/extractors/injured_in_war_flag_extractor.py
@@ -1,0 +1,25 @@
+from book_extractors.common.extractors.base_extractor import BaseExtractor
+import regex
+
+
+class InjuredInWarFlagExtractor(BaseExtractor):
+    extraction_key = 'injuredInWarFlag'
+
+    def __init__(self, key_of_cursor_location_dependent, options):
+        super(InjuredInWarFlagExtractor, self).__init__(key_of_cursor_location_dependent, options)
+        self.OPTIONS = regex.UNICODE
+        self.INJURED_IN_WAR_PATTERN = r'(?:haavoi){s<=1}|(?<!S)(otainvalidi){s<=1}(?:\s|,|\.)'
+        self.REGEX_INJURED_IN_WAR = regex.compile(self.INJURED_IN_WAR_PATTERN, self.OPTIONS)
+
+    def _extract(self, entry, extraction_results, extraction_metadata):
+        if extraction_results['primaryPerson']['name']['gender'] == 'Female':
+            return self._add_to_extraction_results(None, extraction_results, extraction_metadata)
+
+        injured_in_war = self._check_injured_in_war(entry['text'])
+
+        return self._add_to_extraction_results(injured_in_war, extraction_results, extraction_metadata)
+
+    def _check_injured_in_war(self, text):
+        text = text.replace('-', '')
+        injured = regex.search(self.REGEX_INJURED_IN_WAR, text)
+        return injured is not None

--- a/book_extractors/karelians/extraction/extractors/tests/test_injured_in_war_flag.py
+++ b/book_extractors/karelians/extraction/extractors/tests/test_injured_in_war_flag.py
@@ -1,0 +1,67 @@
+import pytest
+from book_extractors.karelians.extraction.extractors.injured_in_war_flag_extractor import InjuredInWarFlagExtractor
+
+class TestInjuredInWarFlag:
+
+    @pytest.yield_fixture(autouse=True)
+    def extractor(self):
+        return InjuredInWarFlagExtractor(None, None)
+
+    def _verify_flags(self, expected_flags_and_texts, extractor, gender = 'Male'):
+        extraction_results = {'primaryPerson': {'name': {'gender': gender}}}
+        flag = 'injuredInWarFlag'
+
+        for e in expected_flags_and_texts:
+            results, metadata = extractor.extract({'text': e[0]}, extraction_results, {})
+            assert results[flag] is e[1]
+
+    def should_return_true_if_text_contains_mentions_of_being_injured(self, extractor):
+        self._verify_flags([
+            ('Nyymi on sotamies, ja hän palveli JP 1;ssä. Hän haavoittui v. -44 ja on 30 %;n sotainvalidi.', True),
+            ('Sodassa haavoittumisen vuoksi hän on 30 % invaliidi.', True)
+        ], extractor)
+
+    def should_return_true_if_text_contains_mentions_of_being_injured_and_a_hyphen(self, extractor):
+        self._verify_flags([
+            ('Nyymi on sotamies, ja hän palveli JP 1;ssä. Hän haavoit-tui v. -44 ja on 30 %;n sotainvalidi.', True)
+        ], extractor)
+
+    def should_return_true_if_text_contains_mentions_of_being_injured_and_a_typo(self, extractor):
+        self._verify_flags([
+            ('Joku on sotamies ja palvellut jatkosodassa JvKoulK 2:ssa ja 4./JR 6:ssa. Hän haavoi7tui kaksi kertaa.', True)
+        ], extractor)
+
+    def should_return_true_if_text_contains_mentions_of_being_warhandicapped(self, extractor):
+        self._verify_flags([
+            ('asuvat osakehuoneistossa. Rakennusmestari Joku on 20 %:n sotainvalidi. Hänelle on myönnetty', True)
+        ], extractor)
+
+    def should_return_true_if_text_contains_mentions_of_being_warhandicapped_and_a_hyphen(self, extractor):
+        self._verify_flags([
+            ('asuvat osakehuoneistossa. Rakennusmestari Joku on 20 %:n sota-invalidi. Hänelle on myönnetty', True)
+        ], extractor)
+
+    def should_return_true_if_text_contains_mentions_of_being_warhandicapped_and_a_typo(self, extractor):
+        self._verify_flags([
+            ('Hän on sotamies ja palvellut jatkosodassa JR 6:ssa. Hän on 60 %:n sotainvalibi.', True)
+        ], extractor)
+
+    def should_return_false_if_text_does_not_mention_injury_or_being_warhandicapped(self, extractor):
+        self._verify_flags([
+            ('Joku Meikäläinen on kersantti ja palveli talvisodassa 1./VKK:ssa, 2./VP 19:ssä ja '
+             '2./VP 1 :ssä sekä jatkosodassa 1./RaskPsto 14:s sä. Hänelle on myönnetty Vm 2, Ts '
+             'mm sekä Js mm. Hän on Lauritsalan Kisan jäsen. Hän kuuluu Paperityöväenliittoon Ul'
+             'koilu ja pihanhoito sekä hiihto ovat hänen mieliharrastuksiaan. Rouva Ni-me-tön ku'
+             'uluu Liiketyöntekijöihin. Käsityöt ovat hänen harrastuksiaan.', False)
+        ], extractor)
+
+    def should_return_false_if_text_mentions_warhandicapped_in_wrong_context(self, extractor):
+        self._verify_flags([
+            ('Satunnainen heppuu asuu yhdessä äitinsä, Satunnaisen Äidin kanssa sotainvalidien talossa.', False),
+            ('Hän kuuluu Karjalaseuraan, Rakennustyöväen liittoon ja Sotainvalidien Veljesliittoon.', False)
+        ], extractor)
+
+    def should_return_none_if_primaryperson_gender_is_female(self, extractor):
+        self._verify_flags([
+            ('Hän on sotamies ja palvellut jatkosodassa JR 6:ssa. Hän on 60 %:n sotainvalidi.', None)
+        ], extractor, gender='Female')

--- a/book_extractors/karelians/main.py
+++ b/book_extractors/karelians/main.py
@@ -15,6 +15,7 @@ from book_extractors.karelians.extraction.extractors.child_extractor import Chil
 from book_extractors.karelians.extraction.extractors.farm_extractor import FarmDetailsExtractor
 from book_extractors.common.extractors.kaira_id_extractor import KairaIdExtractor
 from book_extractors.common.extractors.previous_marriages_flag_extractor import PreviousMarriagesFlagExtractor
+from book_extractors.karelians.extraction.extractors.injured_in_war_flag_extractor import InjuredInWarFlagExtractor
 from shared.gender_extract import Gender
 
 BOOK_SERIES_ID = 'siirtokarjalaiset'    # Used to identify this book series in xml files
@@ -37,6 +38,7 @@ class KarelianBooksExtractor:
             configure_extractor(BirthdayExtractor, path='primaryPerson', depends_on_match_position_of_extractor=FormerSurnameExtractor),
             configure_extractor(BirthdayLocationExtractor, path='primaryPerson', depends_on_match_position_of_extractor=BirthdayExtractor),
             configure_extractor(PreviousMarriagesFlagExtractor, path='primaryPerson'),
+            configure_extractor(InjuredInWarFlagExtractor, path='primaryPerson'),
             configure_extractor(MigrationRouteExtractor, path='primaryPerson'),
             configure_extractor(OmakotitaloExtractor, path='primaryPerson'),
             configure_extractor(SpouseExtractor),


### PR DESCRIPTION
Added an extractor that checks the data for keywords that indicate
the person in question was injured during a war. The flag is True
or False for males, and should always be null for females. Added
tests for the flag extractor and the extractor is present in the
extraction pipeline.