### PR TITLE
Implement an extractor for war related data

### DIFF
--- a/book_extractors/karelians/extraction/extractors/injured_in_war_flag_extractor.py
+++ b/book_extractors/karelians/extraction/extractors/injured_in_war_flag_extractor.py
@@ -12,9 +12,6 @@ class InjuredInWarFlagExtractor(BaseExtractor):
         self.REGEX_INJURED_IN_WAR = regex.compile(self.INJURED_IN_WAR_PATTERN, self.OPTIONS)
 
     def _extract(self, entry, extraction_results, extraction_metadata):
-        if extraction_results['primaryPerson']['name']['gender'] == 'Female':
-            return self._add_to_extraction_results(None, extraction_results, extraction_metadata)
-
         injured_in_war = self._check_injured_in_war(entry['text'])
 
         return self._add_to_extraction_results(injured_in_war, extraction_results, extraction_metadata)

--- a/book_extractors/karelians/extraction/extractors/war_data_extractor.py
+++ b/book_extractors/karelians/extraction/extractors/war_data_extractor.py
@@ -1,0 +1,32 @@
+from book_extractors.common.extractors.base_extractor import BaseExtractor
+from book_extractors.extraction_pipeline import ExtractionPipeline, configure_extractor
+from book_extractors.karelians.extraction.extractors.injured_in_war_flag_extractor import InjuredInWarFlagExtractor
+
+
+class WarDataExtractor(BaseExtractor):
+    extraction_key = 'warData'
+
+    def __init__(self, key_of_cursor_location_dependent, options):
+        super(WarDataExtractor, self).__init__(key_of_cursor_location_dependent, options)
+
+        self._sub_extraction_pipeline = ExtractionPipeline([
+            configure_extractor(InjuredInWarFlagExtractor)
+        ])
+
+    def _extract(self, entry, extraction_results, extraction_metadata):
+        results, metadata = self._extract_war_data(entry['text'])
+        return self._add_to_extraction_results(self._nullify_injured_flag_for_females(results, extraction_results),
+                                               extraction_results,
+                                               extraction_metadata)
+
+    # FIXME: Dirty post-processing hack to null injuredInWarFlag if the person is female, fix after architecture changes
+    def _nullify_injured_flag_for_females(self, extracted_data, extraction_results):
+        for key, value in extracted_data.items():
+            if value:
+                if extraction_results['primaryPerson']['name']['gender'] == 'Female':
+                    extracted_data['injuredInWarFlag'] = None
+
+        return extracted_data
+
+    def _extract_war_data(self, text):
+        return self._sub_extraction_pipeline.process({'text': text})

--- a/book_extractors/karelians/main.py
+++ b/book_extractors/karelians/main.py
@@ -13,9 +13,9 @@ from book_extractors.karelians.extraction.extractors.migration_route_extractors 
 from book_extractors.karelians.extraction.extractors.spouse_extractor import SpouseExtractor
 from book_extractors.karelians.extraction.extractors.child_extractor import ChildExtractor
 from book_extractors.karelians.extraction.extractors.farm_extractor import FarmDetailsExtractor
+from book_extractors.karelians.extraction.extractors.war_data_extractor import WarDataExtractor
 from book_extractors.common.extractors.kaira_id_extractor import KairaIdExtractor
 from book_extractors.common.extractors.previous_marriages_flag_extractor import PreviousMarriagesFlagExtractor
-from book_extractors.karelians.extraction.extractors.injured_in_war_flag_extractor import InjuredInWarFlagExtractor
 from shared.gender_extract import Gender
 
 BOOK_SERIES_ID = 'siirtokarjalaiset'    # Used to identify this book series in xml files
@@ -38,7 +38,7 @@ class KarelianBooksExtractor:
             configure_extractor(BirthdayExtractor, path='primaryPerson', depends_on_match_position_of_extractor=FormerSurnameExtractor),
             configure_extractor(BirthdayLocationExtractor, path='primaryPerson', depends_on_match_position_of_extractor=BirthdayExtractor),
             configure_extractor(PreviousMarriagesFlagExtractor, path='primaryPerson'),
-            configure_extractor(InjuredInWarFlagExtractor, path='primaryPerson'),
+            configure_extractor(WarDataExtractor, path='primaryPerson'),
             configure_extractor(MigrationRouteExtractor, path='primaryPerson'),
             configure_extractor(OmakotitaloExtractor, path='primaryPerson'),
             configure_extractor(SpouseExtractor),


### PR DESCRIPTION
Make an extractor that has a subpipeline for extracting war related
data. The war data is saved under a new key, warData, in
primaryPerson. Changed the extraction pipeline in main.py to use
the WarDataExtractor and moved InjuredInWarFlagExtractor to the
subpipeline.